### PR TITLE
API Parametrelerinde Array

### DIFF
--- a/src/Sendloop/SendloopAPI3.php
+++ b/src/Sendloop/SendloopAPI3.php
@@ -55,11 +55,9 @@ class SendloopAPI3 {
 
 		$APIURL = $this->MakeURL($APICommand);
 
-		$ParametersArray = array('APIKey='.$this->APIKey);
-		foreach ($Parameters as $Key => $Value) {
-			$ParametersArray[] = "$Key=$Value";
-		}
-		$ParametersString = implode('&',$ParametersArray);
+		$Parameters['APIKey'] = $this->APIKey;
+
+		$ParametersString = http_build_query($Parameters);
 
 		curl_setopt($cURL,CURLOPT_URL,$APIURL);
 		curl_setopt($cURL,CURLOPT_POST,1);


### PR DESCRIPTION
Multi-dimensional arrayleri API  parametresi olarak gönderilirken, string halde 'Key=Array' şeklinde gidiyordu. Bu durumda "Fields[CustomField330]=Test 2" gibi parametreler gönderilemiyordu.

Bu sorun düzeltildi.
